### PR TITLE
fix : Resolved a styling issue

### DIFF
--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -325,7 +325,7 @@ export function Thread() {
         <StickToBottom className="relative flex-1 overflow-hidden">
           <StickyToBottomContent
             className={cn(
-              "absolute inset-0 overflow-y-scroll [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-track]:bg-transparent",
+              "absolute px-4 inset-0 overflow-y-scroll [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-track]:bg-transparent",
               !chatStarted && "flex flex-col items-stretch mt-[25vh]",
               chatStarted && "grid grid-rows-[1fr_auto]",
             )}
@@ -356,7 +356,7 @@ export function Thread() {
               </>
             }
             footer={
-              <div className="sticky flex flex-col items-center gap-8 bottom-0 px-4 bg-white">
+              <div className="sticky flex flex-col items-center gap-8 bottom-0 bg-white">
                 {!chatStarted && (
                   <div className="flex gap-3 items-center">
                     <LangGraphLogoSVG className="flex-shrink-0 h-8" />

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -84,7 +84,7 @@ export function HumanMessage({
             onSubmit={handleSubmitEdit}
           />
         ) : (
-          <p className="text-right px-4 py-2 rounded-3xl bg-muted w-fit ml-auto">
+          <p className="px-4 py-2 rounded-3xl bg-muted w-fit ml-auto whitespace-pre-wrap">
             {contentString}
           </p>
         )}

--- a/src/components/thread/messages/tool-calls.tsx
+++ b/src/components/thread/messages/tool-calls.tsx
@@ -44,7 +44,7 @@ export function ToolCalls({
                       </td>
                       <td className="px-4 py-2 text-sm text-gray-500">
                         {isComplexValue(value) ? (
-                          <code className="bg-gray-50 rounded px-2 py-1 font-mono text-sm">
+                          <code className="bg-gray-50 rounded px-2 py-1 font-mono text-sm break-all">
                             {JSON.stringify(value, null, 2)}
                           </code>
                         ) : (
@@ -148,7 +148,7 @@ export function ToolResult({ message }: { message: ToolMessage }) {
                           </td>
                           <td className="px-4 py-2 text-sm text-gray-500">
                             {isComplexValue(value) ? (
-                              <code className="bg-gray-50 rounded px-2 py-1 font-mono text-sm">
+                              <code className="bg-gray-50 rounded px-2 py-1 font-mono text-sm break-all">
                                 {JSON.stringify(value, null, 2)}
                               </code>
                             ) : (


### PR DESCRIPTION
I'm submitting this PR with a few UI fixes.

Please feel free to share any feedback—I'd be happy to make further adjustments and update the PR accordingly.

1. Issue where StickyToBottomContent fills the entire screen on viewports narrower than 800px
<table> <tr><th>Before</th><th>After</th></tr> <tr><td><img width="836" alt="Before" src="https://github.com/user-attachments/assets/ac935738-e520-40b6-a1a3-f0ac622c143f" /></td><td><img width="836" alt="After" src="https://github.com/user-attachments/assets/41fb3726-366f-4f69-8218-3301862df720" /></td></tr> </table>
2. Issue where the tool call box overflows outside its container when long, unbreakable text is present
<table> <tr><th>Before</th><th>After</th></tr> <tr><td><img width="1486" alt="Before" src="https://github.com/user-attachments/assets/7d99dde0-798c-4416-9414-ba49c5f4ff30" /></td><td><img width="1485" alt="After" src="https://github.com/user-attachments/assets/af348ea0-4c69-44b9-afa3-7a878e6e7af3" /> </td></tr> </table>
3. Issue where line breaks in user input were not being rendered correctly in HumanMessage
<table> <tr><th>Input</th><th>Before</th><th>After</th></tr> <tr><td><img width="1485" alt="Input" src="https://github.com/user-attachments/assets/5a7081c8-8e24-4704-8d65-6865dbae6e6d" /></td><td><img width="1482" alt="Before" src="https://github.com/user-attachments/assets/f4338bab-eb2c-4625-b3c1-09471f8f4643" /></td><td><img width="1483" alt="After" src="https://github.com/user-attachments/assets/1fae715d-587c-42ec-b333-0aaef6dc271c" /> </td></tr> </table>