### PR TITLE
Fix primitive types in tool response not being displayed

### DIFF
--- a/src/components/thread/messages/tool-calls.tsx
+++ b/src/components/thread/messages/tool-calls.tsx
@@ -74,7 +74,7 @@ export function ToolResult({ message }: { message: ToolMessage }) {
   try {
     if (typeof message.content === "string") {
       parsedContent = JSON.parse(message.content);
-      isJsonContent = true;
+      isJsonContent = isComplexValue(parsedContent);
     }
   } catch {
     // Content is not JSON, use as is


### PR DESCRIPTION
If a tool response returns a primitive type, such as `10`, `isJsonContent` would be set to `true`. However the display logic assumes that the content is a json object or array and hence the value won't be displayed. This fixes the issue by only setting isJsonContent to true for non-primitive types.