### PR TITLE
feat : Support file uploads #56

### DIFF
--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -1,7 +1,7 @@
 import { useStreamContext } from "@/providers/Stream";
 import { Message } from "@langchain/langgraph-sdk";
 import { useState } from "react";
-import { getContentString } from "../utils";
+import { getContentImageUrls, getContentString } from "../utils";
 import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import { BranchSwitcher, CommandBar } from "./shared";
@@ -46,6 +46,7 @@ export function HumanMessage({
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState("");
   const contentString = getContentString(message.content);
+  const contentImageUrls = getContentImageUrls(message.content);
 
   const handleSubmitEdit = () => {
     setIsEditing(false);
@@ -84,9 +85,22 @@ export function HumanMessage({
             onSubmit={handleSubmitEdit}
           />
         ) : (
-          <p className="bg-muted ml-auto w-fit rounded-3xl px-4 py-2 whitespace-pre-wrap">
-            {contentString}
-          </p>
+          <div className="flex flex-col gap-2">
+            {contentImageUrls.length > 0 && (
+              <div className="flex flex-wrap justify-end gap-2">
+                {contentImageUrls.map((imageUrl) => (
+                  <img
+                    src={imageUrl}
+                    alt="uploaded image"
+                    className="bg-muted h-16 w-16 rounded-md object-cover"
+                  />
+                ))}
+              </div>
+            )}
+            <p className="bg-muted ml-auto w-fit rounded-3xl px-4 py-2 text-right whitespace-pre-wrap">
+              {contentString}
+            </p>
+          </div>
         )}
 
         <div

--- a/src/components/thread/utils.ts
+++ b/src/components/thread/utils.ts
@@ -7,3 +7,13 @@ export function getContentString(content: Message["content"]): string {
     .map((c) => c.text);
   return texts.join(" ");
 }
+
+export function getContentImageUrls(content: Message["content"]): string[] {
+  if (typeof content === "string") return [];
+  return content
+    .filter((c) => c.type === "image_url")
+    .map((c) => {
+      if (typeof c.image_url === "string") return c.image_url;
+      return c.image_url.url;
+    });
+}


### PR DESCRIPTION
There might have been other plans regarding this issue (#56),
but I needed file upload support for a project I’m working on, so I went ahead and implemented it.
While I was at it, I thought it might be useful here too, so I’m submitting this pull request.

If you have any feedback or see anything that needs improvement, feel free to let me know — it’s very welcome!
	•	**Implementation**: Used [MessageContentImageUrl](https://github.com/langchain-ai/langchainjs/blob/40a1b1af772790a2a3b1c5029f9c53f769210473/langchain-core/src/messages/base.ts#L54C1-L66C1) from [MessageContentComplex](https://github.com/langchain-ai/langchainjs/blob/40a1b1af772790a2a3b1c5029f9c53f769210473/langchain-core/src/messages/base.ts#L59C13-L59C34) in langgraph.
	•	**Design Reference**: Took a lot of inspiration from ChatGPT.
	•	**Testing**: Verified functionality using the [React Agent Template](https://github.com/langchain-ai/react-agent) from langgraph.
	•	**Preview**: Deployed a preview version on Vercel for easier review: https://agent-chat-ui-chi.vercel.app/

## ScreenShots

1. File Upload Support & Display Uploaded Files Above Input Textarea
<table>
<tr>
<th>Before</th>
<th>After1</th>
<th>After2</th>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/0b4ca578-9a69-47aa-a16a-df2206c70c8f" width="300"/></td>
<td><img src="https://github.com/user-attachments/assets/770098d4-845d-4147-9674-1f7b24d36fd6" width="300"/></td>
<td><img src="https://github.com/user-attachments/assets/0ead0a22-c3e7-41ef-aba0-34f4c990b78e" width="300"/></td>
</tr>
</table>

2. Uploaded Files are Displayed in the Human Message Component
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/59939759-5bf5-4ecd-837e-95a8f09d8fd0" width="300"/></td>
<td><img src="https://github.com/user-attachments/assets/341ea4d0-7118-412c-a565-ebeb0a31aa47" width="300"/></td>
</tr>
</table>

