### PR TITLE
feat: support optional fixed backend configuration for deployment URL and assistant ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # LangGraph Configuration
+# Use the following environement variables if you want to provide defaults
+# for the LangGraph API URL and Assistant ID but still allow the user to override them in the UI.
 NEXT_PUBLIC_API_URL=http://localhost:2024
 NEXT_PUBLIC_ASSISTANT_ID=agent
+
+# Use the following environement variables if you want to prevent the user from overriding the API URL and Assistant ID in the UI.
+# NEXT_PUBLIC_FIXED_API_URL=https://chatbot.example.com
+# NEXT_PUBLIC_FIXED_ASSISTANT_ID=agent
+
 # Do NOT prefix this with "NEXT_PUBLIC_" as we do not want this exposed in the client.
 LANGSMITH_API_KEY=
 

--- a/src/components/thread/agent-inbox/components/thread-actions-view.tsx
+++ b/src/components/thread/agent-inbox/components/thread-actions-view.tsx
@@ -81,10 +81,13 @@ export function ThreadActionsView({
   } = useInterruptedActions({
     interrupt,
   });
-  const [apiUrl] = useQueryState("apiUrl");
+  const envFixedApiUrl = process.env.NEXT_PUBLIC_FIXED_API_URL;
+  const [apiUrlParam] = useQueryState("apiUrl");
+
+  const finalApiUrl = envFixedApiUrl || apiUrlParam;
 
   const handleOpenInStudio = () => {
-    if (!apiUrl) {
+    if (!finalApiUrl) {
       toast.error("Error", {
         description: "Please set the LangGraph deployment URL in settings.",
         duration: 5000,
@@ -94,7 +97,10 @@ export function ThreadActionsView({
       return;
     }
 
-    const studioUrl = constructOpenInStudioURL(apiUrl, threadId ?? undefined);
+    const studioUrl = constructOpenInStudioURL(
+      finalApiUrl,
+      threadId ?? undefined,
+    );
     window.open(studioUrl, "_blank");
   };
 
@@ -111,7 +117,7 @@ export function ThreadActionsView({
           {threadId && <ThreadIdCopyable threadId={threadId} />}
         </div>
         <div className="flex flex-row items-center justify-start gap-2">
-          {apiUrl && (
+          {finalApiUrl && (
             <Button
               size="sm"
               variant="outline"

--- a/src/providers/Stream.tsx
+++ b/src/providers/Stream.tsx
@@ -128,32 +128,29 @@ export const StreamProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
   // Get environment variables
-  const envApiUrl: string | undefined = process.env.NEXT_PUBLIC_API_URL;
-  const envAssistantId: string | undefined =
-    process.env.NEXT_PUBLIC_ASSISTANT_ID;
+  const fixedApiUrl = process.env.NEXT_PUBLIC_FIXED_API_URL;
+  const fixedAssistantId = process.env.NEXT_PUBLIC_FIXED_ASSISTANT_ID;
+  const hasFixedValues = fixedApiUrl && fixedAssistantId;
 
-  // Use URL params with env var fallbacks
   const [apiUrl, setApiUrl] = useQueryState("apiUrl", {
-    defaultValue: envApiUrl || "",
+    defaultValue: process.env.NEXT_PUBLIC_API_URL || "",
   });
   const [assistantId, setAssistantId] = useQueryState("assistantId", {
-    defaultValue: envAssistantId || "",
+    defaultValue: process.env.NEXT_PUBLIC_ASSISTANT_ID || "",
   });
 
-  // For API key, use localStorage with env var fallback
-  const [apiKey, _setApiKey] = useState(() => {
-    const storedKey = getApiKey();
-    return storedKey || "";
-  });
-
+  const [apiKey, _setApiKey] = useState(() => getApiKey() || "");
   const setApiKey = (key: string) => {
     window.localStorage.setItem("lg:chat:apiKey", key);
     _setApiKey(key);
   };
 
-  // Determine final values to use, prioritizing URL params then env vars
-  const finalApiUrl = apiUrl || envApiUrl;
-  const finalAssistantId = assistantId || envAssistantId;
+  const finalApiUrl = hasFixedValues
+    ? fixedApiUrl!
+    : apiUrl || process.env.NEXT_PUBLIC_API_URL || "";
+  const finalAssistantId = hasFixedValues
+    ? fixedAssistantId!
+    : assistantId || process.env.NEXT_PUBLIC_ASSISTANT_ID || "";
 
   // Show the form if we: don't have an API URL, or don't have an assistant ID
   if (!finalApiUrl || !finalAssistantId) {


### PR DESCRIPTION
his PR introduces an optional “fixed backend” configuration mode to the Agent Chat UI project.

**Problem**

Currently, users are always required to manually input the apiUrl (deployment URL) and assistantId (assistant/graph ID) via a form. This is inconvenient or undesirable in public deployments or tightly controlled setups.

**Solution**

If the new environment variables `NEXT_PUBLIC_FIXED_API_URL` and `NEXT_PUBLIC_FIXED_ASSISTANT_ID` are set:

- The configuration form is completely bypassed.
- The chat UI connects directly to the specified deployment backend.
- Inputs for `apiUrl` and `assistantId` are ignored (no need for URL parameters).

**Key Changes**

- Updated `StreamProvider` to detect fixed values and skip user input if configured.
- Updated `ThreadActionsView` to fallback to fixed API URL when opening LangGraph Studio.

**Environment Variables Introduced**

```bash
NEXT_PUBLIC_FIXED_API_URL=http://localhost:2024
NEXT_PUBLIC_FIXED_ASSISTANT_ID=my-agent-id
```

**Backward Compatibility**

If these environment variables **are not set**, the application behaves **exactly as before** — no user experience changes.
