### PR TITLE
Drag & Drop Improvements

### DIFF
--- a/src/components/thread/ContentBlocksPreview.tsx
+++ b/src/components/thread/ContentBlocksPreview.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Base64ContentBlock } from "@langchain/core/messages";
-import { MultimodalPreview } from "../ui/MultimodalPreview";
+import { MultimodalPreview } from "./MultimodalPreview";
 import { cn } from "@/lib/utils";
 
 interface ContentBlocksPreviewProps {

--- a/src/components/thread/MultimodalPreview.tsx
+++ b/src/components/thread/MultimodalPreview.tsx
@@ -18,15 +18,6 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
   className,
   size = "md",
 }) => {
-  // Sizing
-  const sizeMap = {
-    sm: "h-10 w-10 text-base",
-    md: "h-16 w-16 text-lg",
-    lg: "h-24 w-24 text-xl",
-  };
-  const iconSize: string =
-    typeof sizeMap[size] === "string" ? sizeMap[size] : sizeMap["md"];
-
   // Image block
   if (
     block.type === "image" &&
@@ -72,28 +63,28 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
     return (
       <div
         className={cn(
-          "relative flex items-center gap-2 rounded-md border bg-gray-100 px-3 py-2",
+          "relative flex items-start gap-2 rounded-md border bg-gray-100 px-3 py-2",
           className,
         )}
       >
-        <File
-          className={cn(
-            "flex-shrink-0 text-teal-700",
-            size === "sm" ? "h-5 w-5" : "h-7 w-7",
-          )}
-        />
+        <div className="flex flex-shrink-0 flex-col items-start justify-start">
+          <File
+            className={cn(
+              "text-teal-700",
+              size === "sm" ? "h-5 w-5" : "h-7 w-7",
+            )}
+          />
+        </div>
         <span
-          className={cn(
-            "truncate text-sm text-gray-800",
-            size === "sm" ? "max-w-[80px]" : "max-w-[160px]",
-          )}
+          className={cn("min-w-0 flex-1 text-sm break-all text-gray-800")}
+          style={{ wordBreak: "break-all", whiteSpace: "pre-wrap" }}
         >
           {String(filename)}
         </span>
         {removable && (
           <button
             type="button"
-            className="ml-2 rounded-full bg-gray-200 p-1 text-teal-700 hover:bg-gray-300"
+            className="ml-2 self-start rounded-full bg-gray-200 p-1 text-teal-700 hover:bg-gray-300"
             onClick={onRemove}
             aria-label="Remove PDF"
           >

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -445,17 +445,12 @@ export function Thread() {
                   <div
                     ref={dropRef}
                     className={cn(
-                      "bg-muted relative z-10 mx-auto mb-8 w-full max-w-3xl rounded-2xl border shadow-xs transition-all",
-                      dragOver ? "border-primary border-2 border-dotted" : "",
+                      "bg-muted relative z-10 mx-auto mb-8 w-full max-w-3xl rounded-2xl shadow-xs transition-all",
+                      dragOver
+                        ? "border-primary border-2 border-dotted"
+                        : "border border-solid",
                     )}
                   >
-                    {dragOver && (
-                      <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-black/40">
-                        <span className="text-lg font-semibold text-white">
-                          Drop file here
-                        </span>
-                      </div>
-                    )}
                     <form
                       onSubmit={handleSubmit}
                       className="mx-auto grid max-w-3xl grid-rows-[1fr_auto] gap-2"

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -133,6 +133,7 @@ export function Thread() {
     dropRef,
     removeBlock,
     resetBlocks,
+    dragOver,
   } = useFileUpload();
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
@@ -442,8 +443,18 @@ export function Thread() {
 
                   <div
                     ref={dropRef}
-                    className="bg-muted relative z-10 mx-auto mb-8 w-full max-w-3xl rounded-2xl border shadow-xs"
+                    className={cn(
+                      "bg-muted relative z-10 mx-auto mb-8 w-full max-w-3xl rounded-2xl border shadow-xs transition-all",
+                      dragOver ? "border-primary border-2 border-dotted" : "",
+                    )}
                   >
+                    {dragOver && (
+                      <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-black/40">
+                        <span className="text-lg font-semibold text-white">
+                          Drop file here
+                        </span>
+                      </div>
+                    )}
                     <form
                       onSubmit={handleSubmit}
                       className="mx-auto grid max-w-3xl grid-rows-[1fr_auto] gap-2"

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -134,6 +134,7 @@ export function Thread() {
     removeBlock,
     resetBlocks,
     dragOver,
+    handlePaste,
   } = useFileUpload();
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
@@ -466,6 +467,7 @@ export function Thread() {
                       <textarea
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
+                        onPaste={handlePaste}
                         onKeyDown={(e) => {
                           if (
                             e.key === "Enter" &&

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import { BranchSwitcher, CommandBar } from "./shared";
 import { MultimodalPreview } from "@/components/thread/MultimodalPreview";
-import type { Base64ContentBlock } from "@langchain/core/messages";
+import { isBase64ContentBlock } from "@/lib/multimodal-utils";
 
 function EditableContent({
   value,
@@ -32,36 +32,6 @@ function EditableContent({
       className="focus-visible:ring-0"
     />
   );
-}
-
-// Type guard for Base64ContentBlock
-function isBase64ContentBlock(block: unknown): block is Base64ContentBlock {
-  if (typeof block !== "object" || block === null || !("type" in block))
-    return false;
-  // file type (legacy)
-  if (
-    (block as { type: unknown }).type === "file" &&
-    "source_type" in block &&
-    (block as { source_type: unknown }).source_type === "base64" &&
-    "mime_type" in block &&
-    typeof (block as { mime_type?: unknown }).mime_type === "string" &&
-    ((block as { mime_type: string }).mime_type.startsWith("image/") ||
-      (block as { mime_type: string }).mime_type === "application/pdf")
-  ) {
-    return true;
-  }
-  // image type (new)
-  if (
-    (block as { type: unknown }).type === "image" &&
-    "source_type" in block &&
-    (block as { source_type: unknown }).source_type === "base64" &&
-    "mime_type" in block &&
-    typeof (block as { mime_type?: unknown }).mime_type === "string" &&
-    (block as { mime_type: string }).mime_type.startsWith("image/")
-  ) {
-    return true;
-  }
-  return false;
 }
 
 export function HumanMessage({

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -89,7 +89,7 @@ export function HumanMessage({
           <div className="flex flex-col gap-2">
             {/* Render images and files if no text */}
             {Array.isArray(message.content) && message.content.length > 0 && (
-              <div className="flex flex-col items-end gap-2">
+              <div className="flex flex-wrap items-end justify-end gap-2">
                 {message.content.reduce<React.ReactNode[]>(
                   (acc, block, idx) => {
                     if (isBase64ContentBlock(block)) {

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -5,7 +5,7 @@ import { getContentString } from "../utils";
 import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import { BranchSwitcher, CommandBar } from "./shared";
-import { MultimodalPreview } from "@/components/ui/MultimodalPreview";
+import { MultimodalPreview } from "@/components/thread/MultimodalPreview";
 import type { Base64ContentBlock } from "@langchain/core/messages";
 
 function EditableContent({

--- a/src/hooks/use-file-upload.tsx
+++ b/src/hooks/use-file-upload.tsx
@@ -99,28 +99,10 @@ export function useFileUpload({
         }
       }
     };
-    const handleWindowDrop = (e: DragEvent) => {
-      dragCounter.current = 0;
-      setDragOver(false);
-    };
-    const handleWindowDragEnd = (e: DragEvent) => {
-      dragCounter.current = 0;
-      setDragOver(false);
-    };
-    window.addEventListener("dragenter", handleWindowDragEnter);
-    window.addEventListener("dragleave", handleWindowDragLeave);
-    window.addEventListener("drop", handleWindowDrop);
-    window.addEventListener("dragend", handleWindowDragEnd);
-
-    const handleDragOver = (e: DragEvent) => {
+    const handleWindowDrop = async (e: DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setDragOver(true);
-    };
-
-    const handleDrop = async (e: DragEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+      dragCounter.current = 0;
       setDragOver(false);
 
       if (!e.dataTransfer) return;
@@ -155,34 +137,52 @@ export function useFileUpload({
         : [];
       setContentBlocks((prev) => [...prev, ...newBlocks]);
     };
+    const handleWindowDragEnd = (e: DragEvent) => {
+      dragCounter.current = 0;
+      setDragOver(false);
+    };
+    window.addEventListener("dragenter", handleWindowDragEnter);
+    window.addEventListener("dragleave", handleWindowDragLeave);
+    window.addEventListener("drop", handleWindowDrop);
+    window.addEventListener("dragend", handleWindowDragEnd);
 
+    // Prevent default browser behavior for dragover globally
+    const handleWindowDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    window.addEventListener("dragover", handleWindowDragOver);
+
+    // Remove element-specific drop event (handled globally)
+    const handleDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragOver(true);
+    };
     const handleDragEnter = (e: DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setDragOver(true);
     };
-
     const handleDragLeave = (e: DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setDragOver(false);
     };
-
     const element = dropRef.current;
     element.addEventListener("dragover", handleDragOver);
-    element.addEventListener("drop", handleDrop);
     element.addEventListener("dragenter", handleDragEnter);
     element.addEventListener("dragleave", handleDragLeave);
 
     return () => {
       element.removeEventListener("dragover", handleDragOver);
-      element.removeEventListener("drop", handleDrop);
       element.removeEventListener("dragenter", handleDragEnter);
       element.removeEventListener("dragleave", handleDragLeave);
       window.removeEventListener("dragenter", handleWindowDragEnter);
       window.removeEventListener("dragleave", handleWindowDragLeave);
       window.removeEventListener("drop", handleWindowDrop);
       window.removeEventListener("dragend", handleWindowDragEnd);
+      window.removeEventListener("dragover", handleWindowDragOver);
       dragCounter.current = 0;
     };
   }, [contentBlocks]);
@@ -200,6 +200,7 @@ export function useFileUpload({
   const handlePaste = async (
     e: React.ClipboardEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => {
+    e.preventDefault();
     const items = e.clipboardData.items;
     if (!items) return;
     const files: File[] = [];

--- a/src/hooks/use-file-upload.tsx
+++ b/src/hooks/use-file-upload.tsx
@@ -86,13 +86,13 @@ export function useFileUpload({
     // Global drag events with counter for robust dragOver state
     const handleWindowDragEnter = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
-        dragCounter.current++;
+        dragCounter.current += 1;
         setDragOver(true);
       }
     };
     const handleWindowDragLeave = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
-        dragCounter.current--;
+        dragCounter.current -= 1;
         if (dragCounter.current <= 0) {
           setDragOver(false);
           dragCounter.current = 0;
@@ -204,7 +204,7 @@ export function useFileUpload({
     const items = e.clipboardData.items;
     if (!items) return;
     const files: File[] = [];
-    for (let i = 0; i < items.length; i++) {
+    for (let i = 0; i < items.length; i += 1) {
       const item = items[i];
       if (item.kind === "file") {
         const file = item.getAsFile();

--- a/src/lib/multimodal-utils.ts
+++ b/src/lib/multimodal-utils.ts
@@ -55,3 +55,35 @@ export async function fileToBase64(file: File): Promise<string> {
     reader.readAsDataURL(file);
   });
 }
+
+// Type guard for Base64ContentBlock
+export function isBase64ContentBlock(
+  block: unknown,
+): block is Base64ContentBlock {
+  if (typeof block !== "object" || block === null || !("type" in block))
+    return false;
+  // file type (legacy)
+  if (
+    (block as { type: unknown }).type === "file" &&
+    "source_type" in block &&
+    (block as { source_type: unknown }).source_type === "base64" &&
+    "mime_type" in block &&
+    typeof (block as { mime_type?: unknown }).mime_type === "string" &&
+    ((block as { mime_type: string }).mime_type.startsWith("image/") ||
+      (block as { mime_type: string }).mime_type === "application/pdf")
+  ) {
+    return true;
+  }
+  // image type (new)
+  if (
+    (block as { type: unknown }).type === "image" &&
+    "source_type" in block &&
+    (block as { source_type: unknown }).source_type === "base64" &&
+    "mime_type" in block &&
+    typeof (block as { mime_type?: unknown }).mime_type === "string" &&
+    (block as { mime_type: string }).mime_type.startsWith("image/")
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
- [x] Drag and Drop Visual Indicator (dotted line + "Drop Files Here Title)
- [x] Allow pasting of files 
- [x]  file preview styling: full width then wrap 
- [x] Move `isBase64ContentBlock()` to `multimodal-utils.ts`
- [x] removed file names from paste
- [x] drag and drop works anywhere on page
- [x] remove solid border, shading, title from d&d
<img width="811" alt="Screenshot 2025-05-20 at 2 28 56 PM" src="https://github.com/user-attachments/assets/37c3850b-3ffe-4af6-9473-427b462cc6e0" />

<img width="961" alt="Screenshot 2025-05-20 at 1 53 51 PM" src="https://github.com/user-attachments/assets/f347fc1f-8d67-4b96-9a20-68b008b5bb04" />
<img width="916" alt="Screenshot 2025-05-20 at 1 54 00 PM" src="https://github.com/user-attachments/assets/c488bb5d-9d1b-49db-b660-7d127d34cff0" />

