### PR TITLE
when set apiUrl and assistantId using env it will not in the query 

### DIFF
--- a/src/providers/Thread.tsx
+++ b/src/providers/Thread.tsx
@@ -34,8 +34,10 @@ function getThreadSearchMetadata(
 }
 
 export function ThreadProvider({ children }: { children: ReactNode }) {
-  const [apiUrl] = useQueryState("apiUrl");
-  const [assistantId] = useQueryState("assistantId");
+  const [apiUrlQS] = useQueryState("apiUrl");
+  const [assistantIdQS] = useQueryState("assistantId");
+  const apiUrl = apiUrlQS || process.env.NEXT_PUBLIC_API_URL;
+  const assistantId = assistantIdQS || process.env.NEXT_PUBLIC_ASSISTANT_ID;
   const [threads, setThreads] = useState<Thread[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
 


### PR DESCRIPTION
When setting apiUrl and assistantId using environment variables, they should not appear in the query parameters. These values must be loaded from environment variables to ensure features like thread history work correctly.
