### PR TITLE
Fix subgraph streaming by adding streamSubgraphs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@langchain/core": "^0.3.44",
     "@langchain/langgraph": "^0.2.63",
-    "@langchain/langgraph-sdk": "^0.0.73",
+    "@langchain/langgraph-sdk": "^0.1.0",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.2.63
         version: 0.2.72(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(react@19.1.0)(zod-to-json-schema@3.24.5(zod@3.24.4))
       '@langchain/langgraph-sdk':
-        specifier: ^0.0.73
-        version: 0.0.73(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(react@19.1.0)
+        specifier: ^0.1.0
+        version: 0.1.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.3
         version: 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -587,6 +587,20 @@ packages:
       '@langchain/core':
         optional: true
       react:
+        optional: true
+
+  '@langchain/langgraph-sdk@0.1.0':
+    resolution: {integrity: sha512-1EKwzwJpgpNqLcRuGG+kLvvhAaPiFWZ9shl/obhL8qDKtYdbR67WCYE+2jUObZ8vKQuCoul16ewJ78g5VrZlKA==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
         optional: true
 
   '@langchain/langgraph@0.2.72':
@@ -3865,6 +3879,17 @@ snapshots:
     optionalDependencies:
       '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4))
       react: 19.1.0
+
+  '@langchain/langgraph-sdk@0.1.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4))
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   '@langchain/langgraph@0.2.72(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(react@19.1.0)(zod-to-json-schema@3.24.5(zod@3.24.4))':
     dependencies:

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -132,7 +132,7 @@ export function Thread() {
     handleFileUpload,
     dropRef,
     removeBlock,
-    resetBlocks: _resetBlocks,
+    resetBlocks,
     dragOver,
     handlePaste,
   } = useFileUpload();

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -131,7 +131,7 @@ export function Thread() {
     handleFileUpload,
     dropRef,
     removeBlock,
-    resetBlocks: _,
+    resetBlocks: _resetBlocks,
     dragOver,
     handlePaste,
   } = useFileUpload();

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -22,7 +22,7 @@ import {
   SquarePen,
   XIcon,
   Plus,
-  CircleX,
+
 } from "lucide-react";
 import { useQueryState, parseAsBoolean } from "nuqs";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
@@ -132,7 +132,7 @@ export function Thread() {
     handleFileUpload,
     dropRef,
     removeBlock,
-    resetBlocks,
+    resetBlocks: _resetBlocks,
     dragOver,
     handlePaste,
   } = useFileUpload();
@@ -219,6 +219,8 @@ export function Thread() {
       { messages: [...toolMessages, newHumanMessage], context },
       {
         streamMode: ["values"],
+        streamSubgraphs: true,
+        streamResumable: true,
         optimisticValues: (prev) => ({
           ...prev,
           context,
@@ -244,6 +246,8 @@ export function Thread() {
     stream.submit(undefined, {
       checkpoint: parentCheckpoint,
       streamMode: ["values"],
+      streamSubgraphs: true,
+      streamResumable: true,
     });
   };
 

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -22,7 +22,6 @@ import {
   SquarePen,
   XIcon,
   Plus,
-
 } from "lucide-react";
 import { useQueryState, parseAsBoolean } from "nuqs";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
@@ -132,7 +131,7 @@ export function Thread() {
     handleFileUpload,
     dropRef,
     removeBlock,
-    resetBlocks,
+    resetBlocks: _,
     dragOver,
     handlePaste,
   } = useFileUpload();

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -59,6 +59,7 @@ export function HumanMessage({
         checkpoint: parentCheckpoint,
         streamMode: ["values"],
         streamSubgraphs: true,
+        streamResumable: true,
         optimisticValues: (prev) => {
           const values = meta?.firstSeenState?.values;
           if (!values) return prev;

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -58,6 +58,7 @@ export function HumanMessage({
       {
         checkpoint: parentCheckpoint,
         streamMode: ["values"],
+        streamSubgraphs: true,
         optimisticValues: (prev) => {
           const values = meta?.firstSeenState?.values;
           if (!values) return prev;

--- a/src/providers/Stream.tsx
+++ b/src/providers/Stream.tsx
@@ -9,6 +9,8 @@ import { useStream } from "@langchain/langgraph-sdk/react";
 import { type Message } from "@langchain/langgraph-sdk";
 import {
   uiMessageReducer,
+  isUIMessage,
+  isRemoveUIMessage,
   type UIMessage,
   type RemoveUIMessage,
 } from "@langchain/langgraph-sdk/react-ui";
@@ -83,10 +85,12 @@ const StreamSession = ({
     assistantId,
     threadId: threadId ?? null,
     onCustomEvent: (event, options) => {
-      options.mutate((prev) => {
-        const ui = uiMessageReducer(prev.ui ?? [], event);
-        return { ...prev, ui };
-      });
+      if (isUIMessage(event) || isRemoveUIMessage(event)) {
+        options.mutate((prev) => {
+          const ui = uiMessageReducer(prev.ui ?? [], event);
+          return { ...prev, ui };
+        });
+      }
     },
     onThreadId: (id) => {
       setThreadId(id);

--- a/src/providers/Stream.tsx
+++ b/src/providers/Stream.tsx
@@ -9,8 +9,6 @@ import { useStream } from "@langchain/langgraph-sdk/react";
 import { type Message } from "@langchain/langgraph-sdk";
 import {
   uiMessageReducer,
-  isUIMessage,
-  isRemoveUIMessage,
   type UIMessage,
   type RemoveUIMessage,
 } from "@langchain/langgraph-sdk/react-ui";
@@ -85,12 +83,10 @@ const StreamSession = ({
     assistantId,
     threadId: threadId ?? null,
     onCustomEvent: (event, options) => {
-      if (isUIMessage(event) || isRemoveUIMessage(event)) {
-        options.mutate((prev) => {
-          const ui = uiMessageReducer(prev.ui ?? [], event);
-          return { ...prev, ui };
-        });
-      }
+      options.mutate((prev) => {
+        const ui = uiMessageReducer(prev.ui ?? [], event);
+        return { ...prev, ui };
+      });
     },
     onThreadId: (id) => {
       setThreadId(id);


### PR DESCRIPTION
### Problem
Subgraph streaming was not working for users with nested graphs (supervisor patterns, multi-agent systems). Customers reported that streaming responses from subgraphs and tools within agents weren't appearing in the chat UI.

https://github.com/langchain-ai/agent-chat-ui/issues/152

### Solution
- **Updated LangGraph SDK** from `^0.0.73` to `^0.1.0` for latest streaming features
- **Added `streamSubgraphs: true`** to all `stream.submit()` calls to enable subgraph streaming
- **Added `streamResumable: true`** 

### Files Changed
- `package.json` - SDK version update
- `pnpm-lock.yaml` - SDK version update
- `src/components/thread/index.tsx` - Main streaming configuration
- `src/components/thread/messages/human.tsx` - Human message streaming