### PR TITLE
fix: add environment variable fallback to ThreadProvider

### DIFF
--- a/src/providers/Thread.tsx
+++ b/src/providers/Thread.tsx
@@ -34,8 +34,18 @@ function getThreadSearchMetadata(
 }
 
 export function ThreadProvider({ children }: { children: ReactNode }) {
-  const [apiUrl] = useQueryState("apiUrl");
-  const [assistantId] = useQueryState("assistantId");
+  // Get environment variables
+  const envApiUrl: string | undefined = process.env.NEXT_PUBLIC_API_URL;
+  const envAssistantId: string | undefined =
+    process.env.NEXT_PUBLIC_ASSISTANT_ID;
+
+  // Use URL params with env var fallbacks
+  const [apiUrl] = useQueryState("apiUrl", {
+    defaultValue: envApiUrl || "",
+  });
+  const [assistantId] = useQueryState("assistantId", {
+    defaultValue: envAssistantId || "",
+  });
   const [threads, setThreads] = useState<Thread[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
 


### PR DESCRIPTION
- ThreadProvider now falls back to NEXT_PUBLIC_API_URL and NEXT_PUBLIC_ASSISTANT_ID environment variables
- Makes ThreadProvider consistent with StreamProvider behavior
- Fixes thread history not working when using environment variables

Fixes #119