### PR TITLE
fix: Display sequential interrupts in multi-turn conversations

### DIFF
--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -427,6 +427,16 @@ export function Thread() {
                       handleRegenerate={handleRegenerate}
                     />
                   )}
+                  {/* Render interrupt after all messages if it exists and we have messages
+                      This handles sequential interrupts where the interrupt comes after previous messages */}
+                  {!hasNoAIOrToolMessages && !!stream.interrupt && !isLoading && (
+                    <AssistantMessage
+                      key="interrupt-msg-after-messages"
+                      message={undefined}
+                      isLoading={isLoading}
+                      handleRegenerate={handleRegenerate}
+                    />
+                  )}
                   {isLoading && !firstTokenReceived && (
                     <AssistantMessageLoading />
                   )}

--- a/src/components/thread/messages/ai.tsx
+++ b/src/components/thread/messages/ai.tsx
@@ -71,22 +71,24 @@ interface InterruptProps {
   interruptValue?: unknown;
   isLastMessage: boolean;
   hasNoAIOrToolMessages: boolean;
+  isInterruptOnly?: boolean;
 }
 
 function Interrupt({
   interruptValue,
   isLastMessage,
   hasNoAIOrToolMessages,
+  isInterruptOnly = false,
 }: InterruptProps) {
   return (
     <>
       {isAgentInboxInterruptSchema(interruptValue) &&
-        (isLastMessage || hasNoAIOrToolMessages) && (
+        (isInterruptOnly || isLastMessage || hasNoAIOrToolMessages) && (
           <ThreadView interrupt={interruptValue} />
         )}
       {interruptValue &&
       !isAgentInboxInterruptSchema(interruptValue) &&
-      (isLastMessage || hasNoAIOrToolMessages) ? (
+      (isInterruptOnly || isLastMessage || hasNoAIOrToolMessages) ? (
         <GenericInterruptView interrupt={interruptValue} />
       ) : null}
     </>
@@ -115,6 +117,9 @@ export function AssistantMessage({
   const hasNoAIOrToolMessages = !thread.messages.find(
     (m) => m.type === "ai" || m.type === "tool",
   );
+
+  // If message is undefined, this component only renders the interrupt
+  const isInterruptOnly = message === undefined;
   const meta = message ? thread.getMessagesMetadata(message) : undefined;
   const threadInterrupt = thread.interrupt;
 
@@ -150,6 +155,7 @@ export function AssistantMessage({
               interruptValue={threadInterrupt?.value}
               isLastMessage={isLastMessage}
               hasNoAIOrToolMessages={hasNoAIOrToolMessages}
+              isInterruptOnly={isInterruptOnly}
             />
           </>
         ) : (
@@ -184,6 +190,7 @@ export function AssistantMessage({
               interruptValue={threadInterrupt?.value}
               isLastMessage={isLastMessage}
               hasNoAIOrToolMessages={hasNoAIOrToolMessages}
+              isInterruptOnly={isInterruptOnly}
             />
             <div
               className={cn(


### PR DESCRIPTION
Fixes an issue where only the first interrupt in a multi-turn conversation would display in the UI. Subsequent interrupts were processed correctly by the backend but failed to render in the interface.

## Problem

The interrupt rendering logic only displayed interrupts when attached to the last message or when no AI/tool messages existed. When users responded to an interrupt, new messages were added to the thread, causing the previous message to no longer be "last", which prevented subsequent interrupts from displaying.

## Solution

**Thread-level interrupt rendering (index.tsx)**
- Added dedicated interrupt component rendering after all messages
- Renders when: interrupt exists, AI/tool messages present, and not loading
- Uses unique key "interrupt-msg-after-messages" to prevent conflicts

**Interrupt component updates (ai.tsx)**
- Added `isInterruptOnly` prop to identify interrupt-only component renders
- Updated `Interrupt` rendering conditions to include `isInterruptOnly`
- When `message === undefined`, component renders only the interrupt content

This preserves existing behavior for message-attached interrupts while enabling sequential interrupts to render independently.

## Testing

Verified with a LangGraph agent triggering multiple sequential interrupts:
- ✅ First interrupt displays correctly
- ✅ User responds to first interrupt
- ✅ Second interrupt displays in UI (previously broken)
- ✅ Multi-turn interrupt conversations work seamlessly

Enables Agent Chat to support graphs requiring multiple human-in-the-loop interactions, matching LangGraph Studio behavior.