### PR TITLE
Add x-auth-scheme header to requests

### DIFF
--- a/src/providers/Stream.tsx
+++ b/src/providers/Stream.tsx
@@ -23,6 +23,7 @@ import { ArrowRight } from "lucide-react";
 import { PasswordInput } from "@/components/ui/password-input";
 import { getApiKey } from "@/lib/api-key";
 import { useThreads } from "./Thread";
+import { DEFAULT_HEADERS } from "./client";
 import { toast } from "sonner";
 
 export type StateType = { messages: Message[]; ui?: UIMessage[] };
@@ -82,6 +83,7 @@ const StreamSession = ({
   const streamValue = useTypedStream({
     apiUrl,
     apiKey: apiKey ?? undefined,
+    defaultHeaders: DEFAULT_HEADERS,
     assistantId,
     threadId: threadId ?? null,
     fetchStateHistory: true,

--- a/src/providers/client.ts
+++ b/src/providers/client.ts
@@ -1,8 +1,11 @@
 import { Client } from "@langchain/langgraph-sdk";
 
+export const DEFAULT_HEADERS = { "x-auth-scheme": "langsmith-api-key" };
+
 export function createClient(apiUrl: string, apiKey: string | undefined) {
   return new Client({
     apiKey,
     apiUrl,
+    defaultHeaders: DEFAULT_HEADERS,
   });
 }


### PR DESCRIPTION
This PR includes the `x-auth-scheme` missing header required by Agent Builder deployments. 