### PR TITLE
Fix: Handle mixed content types in streaming messages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <NuqsAdapter>{children}</NuqsAdapter>
       </body>

--- a/src/components/thread/utils.ts
+++ b/src/components/thread/utils.ts
@@ -9,7 +9,12 @@ import type { Message } from "@langchain/langgraph-sdk";
 export function getContentString(content: Message["content"]): string {
   if (typeof content === "string") return content;
   const texts = content
-    .filter((c): c is { type: "text"; text: string } => c.type === "text")
-    .map((c) => c.text);
-  return texts.join(" ");
+    .map((c) => {
+      // Handle both object format {type: "text", text: "..."} and raw strings
+      if (typeof c === "string") return c;
+      if (typeof c === "object" && c.type === "text" && "text" in c) return c.text;
+      return "";
+    })
+    .filter(Boolean);
+  return texts.join("");
 }


### PR DESCRIPTION
## Issue
Completed streaming messages show only first chunk instead of full text.

## Cause
After streaming, SDK merges content as `[{type:"text",...}, "string"]` but [getContentString](cci:1://file:///Users/kimduhyeon/Desktop/agent-chat-ui/src/components/thread/utils.ts:2:0-19:1) only processed objects.

## Fix
- Handle both object and string types in content array
- Add `suppressHydrationWarning` for browser extensions