### PR TITLE
Add collapsible Reasoning panel for assistant messages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,4 +148,17 @@
   .shadow-inner-left {
     box-shadow: inset 9px 0 6px -1px rgb(0 0 0 / 0.02);
   }
+
+  @keyframes reasoning-shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+
+  .animate-reasoning-shimmer {
+    animation: reasoning-shimmer 2s linear infinite;
+  }
 }

--- a/src/components/thread/messages/ai.tsx
+++ b/src/components/thread/messages/ai.tsx
@@ -1,7 +1,7 @@
 import { parsePartialJson } from "@langchain/core/output_parsers";
 import { useStreamContext } from "@/providers/Stream";
 import { AIMessage, Checkpoint, Message } from "@langchain/langgraph-sdk";
-import { getContentString } from "../utils";
+import { getContentString, getThinkingText } from "../utils";
 import { BranchSwitcher, CommandBar } from "./shared";
 import { MarkdownText } from "../markdown-text";
 import { LoadExternalComponent } from "@langchain/langgraph-sdk/react-ui";
@@ -14,6 +14,7 @@ import { ThreadView } from "../agent-inbox";
 import { useQueryState, parseAsBoolean } from "nuqs";
 import { GenericInterruptView } from "./generic-interrupt";
 import { useArtifact } from "../artifact";
+import Reasoning from "./reasoning";
 
 function CustomComponent({
   message,
@@ -107,6 +108,7 @@ export function AssistantMessage({
   isLoading: boolean;
   handleRegenerate: (parentCheckpoint: Checkpoint | null | undefined) => void;
 }) {
+  const thinkingText = getThinkingText(message);
   const content = message?.content ?? [];
   const contentString = getContentString(content);
   const [hideToolCalls] = useQueryState(
@@ -159,6 +161,13 @@ export function AssistantMessage({
           </>
         ) : (
           <>
+            {thinkingText && (
+              <Reasoning
+                content={thinkingText}
+                defaultExpanded={false}
+                enabled={true}
+              />
+            )}
             {contentString.length > 0 && (
               <div className="py-1">
                 <MarkdownText>{contentString}</MarkdownText>

--- a/src/components/thread/messages/reasoning.tsx
+++ b/src/components/thread/messages/reasoning.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+import { ChevronRight, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  content: string;
+  defaultExpanded?: boolean;
+  enabled?: boolean;
+}
+
+const UPDATE_IDLE_MS = 1000;
+
+const Reasoning = React.memo(function Reasoning({
+  content,
+  defaultExpanded = false,
+  enabled = true,
+}: Props) {
+  const contentId = useId();
+
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  // Skip the first render so we don't show "updating" for an initial fully-ready value.
+  const didMountRef = useRef(false);
+  // `true` means the user pinned the panel open (it won't auto-collapse when updates stop).
+  const userPinnedOpenRef = useRef(false);
+
+  // Detect whether the content is still streaming in.
+  useEffect(() => {
+    if (!enabled) return;
+    if (!content || content.trim() === "") return;
+
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+
+    setIsUpdating(true);
+    setIsExpanded(true);
+
+    const t = setTimeout(() => {
+      setIsUpdating(false);
+    }, UPDATE_IDLE_MS);
+
+    return () => clearTimeout(t);
+  }, [content, enabled]);
+
+  // When updates stop, auto-collapse unless the user pinned it open.
+  useEffect(() => {
+    if (isUpdating) return;
+
+    if (userPinnedOpenRef.current) {
+      setIsExpanded(true);
+      return;
+    }
+
+    setIsExpanded(defaultExpanded);
+  }, [isUpdating, defaultExpanded]);
+
+  const toggleExpand = useCallback(() => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      userPinnedOpenRef.current = next; // User open => pin; user close => unpin.
+      return next;
+    });
+  }, []);
+
+  if (!enabled || !content || content.trim() === "") return null;
+
+  return (
+    <div className="border-border/50 bg-muted/10 mt-2 mb-3 overflow-hidden rounded-lg border shadow-xs">
+      <button
+        type="button"
+        onClick={toggleExpand}
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
+        className={cn(
+          "flex w-full items-center justify-between gap-2 px-3 py-2 text-left",
+          "hover:bg-muted/15 transition-colors",
+          "focus-visible:ring-ring/20 outline-none focus-visible:ring-[3px]",
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <ChevronRight
+            className={cn(
+              "text-muted-foreground size-4 shrink-0 transition-transform",
+              isExpanded ? "rotate-90" : "rotate-0",
+            )}
+          />
+          {isUpdating ? (
+            <span
+              className={cn(
+                "truncate text-sm font-medium",
+                "from-muted-foreground/25 via-muted-foreground to-muted-foreground/25 bg-linear-to-r",
+                "bg-size-[200%_100%] bg-clip-text text-transparent",
+                "animate-reasoning-shimmer",
+              )}
+            >
+              Reasoning...
+            </span>
+          ) : (
+            <span className="text-muted-foreground truncate text-sm font-medium">
+              Reasoning
+            </span>
+          )}
+        </div>
+
+        {isUpdating ? (
+          <Loader2 className="text-muted-foreground size-4 shrink-0 animate-spin" />
+        ) : (
+          <span className="text-muted-foreground text-xs">
+            {isExpanded ? "Collapse" : "Expand"}
+          </span>
+        )}
+      </button>
+
+      <div
+        id={contentId}
+        className={cn(
+          "grid transition-[grid-template-rows,opacity] duration-300 ease-in-out",
+          isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="border-border/50 bg-background/20 overflow-hidden border-t">
+          <div className="max-h-[320px] overflow-y-auto px-3 py-3">
+            <pre className="text-muted-foreground/85 font-mono text-xs leading-relaxed wrap-break-word whitespace-pre-wrap">
+              {content}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default Reasoning;

--- a/src/components/thread/utils.ts
+++ b/src/components/thread/utils.ts
@@ -13,3 +13,38 @@ export function getContentString(content: Message["content"]): string {
     .map((c) => c.text);
   return texts.join(" ");
 }
+
+/**
+ * Best-effort extractor for a model's "thinking / reasoning" text from a LangGraph message.
+ *
+ * Returns the extracted reasoning text (trimmed check), or `undefined` if not present.
+ * Notes:
+ * - This does NOT generate reasoning; it only displays what the model/provider already returned.
+ * - If the message content is streaming, this may be called repeatedly as new chunks arrive.
+ */
+export function getThinkingText(
+  message: Message | undefined,
+): string | undefined {
+  if (!message) return;
+
+  const ak = message.additional_kwargs as Record<string, unknown> | undefined;
+  const v = ak?.reasoning_content;
+  if (typeof v === "string" && v.trim()) return v;
+
+  // "thinking" may be embedded in the message content blocks.
+  const content = message.content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const blk of content as any[]) {
+      if (!blk || typeof blk !== "object") continue;
+      if (blk.type === "thinking") {
+        const t = typeof blk.thinking === "string" ? blk.thinking : "";
+        if (t.trim()) parts.push(t);
+      }
+    }
+    const joined = parts.join("\n\n").trim();
+    if (joined) return joined;
+  }
+
+  return;
+}


### PR DESCRIPTION
## Title

Add optional “Reasoning” panel for AI messages

## Summary

This PR introduces a collapsible “Reasoning” panel for assistant messages. When a model/provider returns reasoning/thinking text (as metadata or content blocks), the UI can display it in a lightweight component without affecting the main message rendering.

## What’s included

- A new `Reasoning` message component:
  - Collapsible panel UI aligned with existing styling tokens
  - Streaming-friendly header state with a left-to-right shimmer while content is updating
  - Allows users to pin the panel open by manually expanding it
- A small helper to extract reasoning text from common message shapes (best-effort)
- Global CSS utility for the shimmer animation
- Wiring in `AssistantMessage` (`ai.tsx`) to render the panel when reasoning is present

## Demo 
![PixPin_2026-01-09_23-50-28](https://github.com/user-attachments/assets/7c0c51c7-cf0d-416a-b116-dafc6daf34ce)


## Component docs

`<Reasoning />`

### Props

- `content: string`  
  The reasoning text to display.
- `defaultExpanded?: boolean` (default: `false`)  
  Whether the panel starts expanded.
- `enabled?: boolean` (default: `true`)  
  Whether the panel is allowed to render at all.

### Behavior

- Returns `null` when `enabled` is `false` or `content` is empty.
- Auto-expands while content is updating (streaming-like behavior).
- When updates stop, it can auto-collapse unless the user pinned it open.

## Usage

```jsx
const thinkingText = getThinkingText(message);

{thinkingText && (
  <Reasoning
    content={thinkingText}
    defaultExpanded={true}
    enabled={true}
  />
)}
```
## Notes

- This feature is additive and does not change existing message rendering when reasoning is absent.