### PR TITLE
feat: Add thread deletion functionality

### DIFF
--- a/src/components/thread/history/index.tsx
+++ b/src/components/thread/history/index.tsx
@@ -12,8 +12,9 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
-import { PanelRightOpen, PanelRightClose } from "lucide-react";
+import { PanelRightOpen, PanelRightClose, Trash2 } from "lucide-react";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { toast } from "sonner";
 
 function ThreadList({
   threads,
@@ -23,6 +24,24 @@ function ThreadList({
   onThreadClick?: (threadId: string) => void;
 }) {
   const [threadId, setThreadId] = useQueryState("threadId");
+  const { deleteThread } = useThreads();
+
+  const handleDelete = async (
+    e: React.MouseEvent<HTMLButtonElement>,
+    deletingThreadId: string,
+  ) => {
+    e.stopPropagation();
+    try {
+      await deleteThread(deletingThreadId);
+      toast.success("Thread deleted");
+      if (deletingThreadId === threadId) {
+        setThreadId(null);
+      }
+    } catch (error) {
+      toast.error("Failed to delete thread");
+      console.error(error);
+    }
+  };
 
   return (
     <div className="flex h-full w-full flex-col items-start justify-start gap-2 overflow-y-scroll [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-track]:bg-transparent">
@@ -41,11 +60,11 @@ function ThreadList({
         return (
           <div
             key={t.thread_id}
-            className="w-full px-1"
+            className="group flex w-full items-center justify-between gap-2 px-1"
           >
             <Button
               variant="ghost"
-              className="w-[280px] items-start justify-start text-left font-normal"
+              className="flex-1 items-start justify-start text-left font-normal"
               onClick={(e) => {
                 e.preventDefault();
                 onThreadClick?.(t.thread_id);
@@ -54,6 +73,14 @@ function ThreadList({
               }}
             >
               <p className="truncate text-ellipsis">{itemText}</p>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="opacity-0 transition-opacity group-hover:opacity-100"
+              onClick={(e) => handleDelete(e, t.thread_id)}
+            >
+              <Trash2 className="h-4 w-4" />
             </Button>
           </div>
         );

--- a/src/providers/Thread.tsx
+++ b/src/providers/Thread.tsx
@@ -19,6 +19,7 @@ interface ThreadContextType {
   setThreads: Dispatch<SetStateAction<Thread[]>>;
   threadsLoading: boolean;
   setThreadsLoading: Dispatch<SetStateAction<boolean>>;
+  deleteThread: (threadId: string) => Promise<void>;
 }
 
 const ThreadContext = createContext<ThreadContextType | undefined>(undefined);
@@ -53,12 +54,23 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
     return threads;
   }, [apiUrl, assistantId]);
 
+  const deleteThread = useCallback(
+    async (threadId: string) => {
+      if (!apiUrl || !assistantId) return;
+      const client = createClient(apiUrl, getApiKey() ?? undefined);
+      await client.threads.delete(threadId);
+      setThreads((prev) => prev.filter((t) => t.thread_id !== threadId));
+    },
+    [apiUrl, assistantId],
+  );
+
   const value = {
     getThreads,
     threads,
     setThreads,
     threadsLoading,
     setThreadsLoading,
+    deleteThread,
   };
 
   return (


### PR DESCRIPTION
- Add deleteThread method to ThreadProvider for deleting threads via API
- Add delete button to thread history with hover reveal animation
- Include error handling and user feedback via toast notifications
- Auto-navigate away from deleted thread if currently viewing it