### PR TITLE
fix: patch 4 medium-severity security alerts (brace-expansion, ajv, mdast-util-to-hast, prismjs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,11 @@
       "@typescript-eslint/typescript-estree>minimatch": "^9.0.6",
       "micromatch>picomatch": "^2.3.2",
       "tinyglobby>picomatch": "^4.0.4",
-      "flat-cache>flatted": "^3.4.2"
+      "flat-cache>flatted": "^3.4.2",
+      "minimatch@9>brace-expansion": "^5.0.5",
+      "eslint>ajv": "^6.14.0",
+      "mdast-util-to-hast": "^13.2.1",
+      "refractor>prismjs": "^1.30.0"
     }
   },
   "packageManager": "pnpm@10.5.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,10 @@ overrides:
   micromatch>picomatch: ^2.3.2
   tinyglobby>picomatch: ^4.0.4
   flat-cache>flatted: ^3.4.2
+  minimatch@9>brace-expansion: ^5.0.5
+  eslint>ajv: ^6.14.0
+  mdast-util-to-hast: ^13.2.1
+  refractor>prismjs: ^1.30.0
 
 importers:
 
@@ -1458,9 +1462,6 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1557,11 +1558,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2667,8 +2668,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -3125,10 +3126,6 @@ packages:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
       react: '>=16.0.0'
-
-  prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -4805,13 +4802,6 @@ snapshots:
       humanize-ms: 1.2.1
     optional: true
 
-  ajv@6.12.6:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4931,12 +4921,12 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5472,7 +5462,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.7
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.1
@@ -6274,7 +6264,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6520,11 +6510,11 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -6812,8 +6802,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.0
 
-  prismjs@1.27.0: {}
-
   prismjs@1.30.0: {}
 
   prop-types@15.8.1:
@@ -6849,7 +6837,7 @@ snapshots:
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       react: 19.1.0
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
@@ -6947,7 +6935,7 @@ snapshots:
     dependencies:
       hastscript: 6.0.0
       parse-entities: 2.0.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -7001,7 +6989,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 


### PR DESCRIPTION
## Security Alert Patch

Resolves 4 medium-severity Dependabot security alerts via pnpm overrides.

### Packages Updated

| Package | Old Version | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|-------------|----------------|----------|-------|---------------|
| brace-expansion (v5) | 5.0.3 | `^5.0.5` via `minimatch@9>brace-expansion` | C (override) | dev-only | CVE-2026-33750 |
| ajv | 6.12.6 | `^6.14.0` via `eslint>ajv` | C (override) | dev-only | CVE-2025-69873 |
| mdast-util-to-hast | 13.2.0 | `^13.2.1` (global) | C (override) | runtime | CVE-2025-66400 |
| prismjs | 1.27.0 | `^1.30.0` via `refractor>prismjs` | C (override) | runtime | CVE-2024-53382 |

Strategy = override (C)
Scope: dev-only = chains through devDependencies only; runtime = bundled into production build

### Dependency Chains

- `brace-expansion@5.x` ← `minimatch@9.0.7` ← `@typescript-eslint/typescript-estree` (devDep)
  - Override scoped to `minimatch@9` to preserve minimatch@3's use of brace-expansion@1.x
- `ajv@6.12.6` ← `eslint@9.39.3` (devDep)
- `mdast-util-to-hast@13.2.0` ← `react-markdown@10.1.0` / `remark-rehype@11.1.2` (runtime dep)
- `prismjs@1.27.0` ← `refractor@3.6.0` ← `react-syntax-highlighter@15.6.1` (runtime dep)

### CVE Details

| CVE | Package | Severity | Summary |
|-----|---------|----------|---------|
| CVE-2026-33750 | brace-expansion | medium | Zero-step sequence causes process hang and memory exhaustion |
| CVE-2025-69873 | ajv | medium | ReDoS when using `$data` option |
| CVE-2025-66400 | mdast-util-to-hast | medium | Unsanitized class attribute |
| CVE-2024-53382 | prismjs | medium | DOM Clobbering vulnerability |

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] Lockfile regenerated (`pnpm install`)
- [x] Prettier passes
- [x] ESLint passes (0 errors)
- [x] TypeScript passes (`tsc --noEmit`)

🤖 Submitted by langster-patch