### PR TITLE
Fix: Resume graph on generic/custom interrupts instead of starting a new run

### DIFF
--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -45,6 +45,7 @@ import {
   ArtifactTitle,
   useArtifactContext,
 } from "./artifact";
+import { isAgentInboxInterruptSchema } from "@/lib/agent-inbox-interrupt";
 
 function StickyToBottomContent(props: {
   content: ReactNode;
@@ -214,23 +215,51 @@ export function Thread() {
     const context =
       Object.keys(artifactContext).length > 0 ? artifactContext : undefined;
 
-    stream.submit(
-      { messages: [...toolMessages, newHumanMessage], context },
-      {
-        streamMode: ["values"],
-        streamSubgraphs: true,
-        streamResumable: true,
-        optimisticValues: (prev) => ({
-          ...prev,
-          context,
-          messages: [
-            ...(prev.messages ?? []),
-            ...toolMessages,
-            newHumanMessage,
-          ],
-        }),
-      },
-    );
+    // When there is a pending interrupt that is NOT a standard HITL interrupt
+    // (i.e. a generic / custom interrupt), resume the graph with Command(resume=...)
+    // instead of starting a new run. This prevents the graph from looping back to START.
+    const hasGenericInterrupt =
+      stream.interrupt && !isAgentInboxInterruptSchema(stream.interrupt);
+
+    if (hasGenericInterrupt) {
+      stream.submit(
+        {},
+        {
+          command: {
+            resume: input.trim(),
+          },
+          streamMode: ["values"],
+          streamSubgraphs: true,
+          streamResumable: true,
+          optimisticValues: (prev) => ({
+            ...prev,
+            messages: [
+              ...(prev.messages ?? []),
+              ...toolMessages,
+              newHumanMessage,
+            ],
+          }),
+        },
+      );
+    } else {
+      stream.submit(
+        { messages: [...toolMessages, newHumanMessage], context },
+        {
+          streamMode: ["values"],
+          streamSubgraphs: true,
+          streamResumable: true,
+          optimisticValues: (prev) => ({
+            ...prev,
+            context,
+            messages: [
+              ...(prev.messages ?? []),
+              ...toolMessages,
+              newHumanMessage,
+            ],
+          }),
+        },
+      );
+    }
 
     setInput("");
     setContentBlocks([]);


### PR DESCRIPTION
### fix issue 

https://github.com/langchain-ai/agent-chat-ui/issues/262

### Problem
When a LangGraph backend uses interrupt() with a custom/generic payload (i.e. not the standard HumanInterrupt schema with action_request / config), the chat input always sends the user's response as a new run. This causes the graph to restart from START, re-triggering the interrupt() node in an infinite loop instead of resuming execution.

Only interrupts matching the isAgentInboxInterruptSchema format (with action_requests and review_configs) were properly handled via Command(resume=...) through the ThreadView / agent-inbox components. Any other interrupt format — like a simple {"type": "human_input_request", "message": "..."} — was displayed read-only via GenericInterruptView with no way to resume the graph from the chat input.

### Solution
Modified handleSubmit in src/components/thread/index.tsx to detect when there is a pending interrupt that is not a standard HITL interrupt. In that case, the user's message is sent as Command(resume=input) instead of new input, allowing the graph to resume correctly.

| Scenario | Before | After |
|---|---|---|
| Standard HITL interrupt (`action_requests`/`review_configs`) | ✅ Handled by `ThreadView` | ✅ No change |
| Generic/custom interrupt | ❌ Chat input starts new run → infinite loop | ✅ Chat input sends `Command(resume=...)` |
| No interrupt (normal chat) | ✅ Normal submit | ✅ No change |