### PR TITLE
fix: ThreadProvider now reads NEXT_PUBLIC_ASSISTANT_ID env var

### DIFF
--- a/src/providers/Thread.tsx
+++ b/src/providers/Thread.tsx
@@ -42,7 +42,9 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
   const [apiUrl] = useQueryState("apiUrl", {
     defaultValue: envApiUrl || "",
   });
-  const [assistantId] = useQueryState("assistantId");
+  const [assistantId] = useQueryState("assistantId", {
+    defaultValue: envAssistantId || "",
+  });
   const [authScheme] = useQueryState("authScheme", {
     defaultValue: envAuthScheme || "",
   });


### PR DESCRIPTION
## Problem

The `ThreadProvider` component does not use `NEXT_PUBLIC_ASSISTANT_ID` as a default value for the `assistantId` query state, while it correctly reads and uses `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_AUTH_SCHEME`.

This inconsistency causes the Thread History panel to remain empty when the application is accessed without explicit query parameters in the URL, even though the environment variables are properly configured.

## Root Cause

`ThreadProvider` reads the environment variable but does not pass it as `defaultValue` to `useQueryState`:

```typescript
// Before (broken)
const [assistantId] = useQueryState("assistantId");  // ❌ No defaultValue
```

Meanwhile, `apiUrl` and `authScheme` correctly use their environment variables:

```typescript
const [apiUrl] = useQueryState("apiUrl", {
  defaultValue: envApiUrl || "",  // ✅ Uses env var
});
```

## Solution

Pass `envAssistantId` as `defaultValue` to `useQueryState`, making it consistent with the other query states:

```typescript
// After (fixed)
const [assistantId] = useQueryState("assistantId", {
  defaultValue: envAssistantId || "",  // ✅ Now uses env var
});
```

## Impact

### Before
- Thread History panel shows loading spinner indefinitely
- Users must manually append query parameters to every URL
- Inconsistent with `StreamProvider` behavior

### After
- Thread History loads correctly with environment variables
- Clean URLs work out of the box
- Consistent behavior across all providers
- Query parameters still override env vars (backward compatible)

## Testing

### Test Case 1: Environment Variables Only
```bash
# .env.local
NEXT_PUBLIC_API_URL=http://localhost:8383/api/v1/agent-protocol
NEXT_PUBLIC_ASSISTANT_ID=my-assistant
```

**URL**: `http://localhost:3000/chat`

**Before**: Thread History empty ❌  
**After**: Thread History loads ✅

### Test Case 2: Query Parameters Override (Backward Compatibility)
```bash
# .env.local
NEXT_PUBLIC_ASSISTANT_ID=default-assistant
```

**URL**: `http://localhost:3000/chat?assistantId=override-assistant`

**Expected**: Uses `override-assistant` (not `default-assistant`) ✅  
**Result**: Works correctly ✅

## Fixes

- Fixes #233

## Related

- This makes `ThreadProvider` consistent with `StreamProvider` (which already uses env vars correctly)
- Follows Next.js conventions for environment variables
- No breaking changes - query parameters still work and override env vars