### PR TITLE
fix: move katex CSS import from client component to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import "katex/dist/katex.min.css";
 import { Inter } from "next/font/google";
 import React from "react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";

--- a/src/components/thread/markdown-text.tsx
+++ b/src/components/thread/markdown-text.tsx
@@ -13,8 +13,6 @@ import { SyntaxHighlighter } from "@/components/thread/syntax-highlighter";
 import { TooltipIconButton } from "@/components/thread/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
-import "katex/dist/katex.min.css";
-
 interface CodeHeaderProps {
   language?: string;
   code: string;


### PR DESCRIPTION
## Problem

`import "katex/dist/katex.min.css"` from `markdown-text.tsx` (client component) causes Next.js 15.5+ to fail with:

```
Module parse failed: Unexpected character '@' (1:0)
File was processed with: next-flight-css-loader
```

Both `next dev` and `next start` return 500.

## Fix

Move CSS import from client component to root layout (server component). Next.js processes CSS correctly in server components via the regular CSS pipeline.

## Verification

- `next build` → passes
- Page loads → 200 OK