### PR TITLE
feat(threads): add thread deletion and pagination in history drawer

### DIFF
--- a/src/components/thread/history/index.tsx
+++ b/src/components/thread/history/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { useThreads } from "@/providers/Thread";
 import { Thread } from "@langchain/langgraph-sdk";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { getContentString } from "../utils";
 import { useQueryState, parseAsBoolean } from "nuqs";
@@ -12,8 +12,127 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
-import { PanelRightOpen, PanelRightClose } from "lucide-react";
+import {
+  PanelRightOpen,
+  PanelRightClose,
+  Trash2,
+  Check,
+  X,
+  Loader2,
+} from "lucide-react";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { TooltipIconButton } from "../tooltip-icon-button";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+function ThreadItem({
+  thread,
+  isActive,
+  onThreadClick,
+  onDelete,
+}: {
+  thread: Thread;
+  isActive: boolean;
+  onThreadClick?: (threadId: string) => void;
+  onDelete: (thread: Thread) => Promise<void>;
+}) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  let itemText = thread.thread_id;
+  if (
+    typeof thread.values === "object" &&
+    thread.values &&
+    "messages" in thread.values &&
+    Array.isArray(thread.values.messages) &&
+    thread.values.messages?.length > 0
+  ) {
+    const firstMessage = thread.values.messages[0];
+    itemText = getContentString(firstMessage.content);
+  }
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setIsDeleting(true);
+    try {
+      await onDelete(thread);
+    } catch (error) {
+      console.error("Failed to delete thread:", error);
+      toast.error("Failed to delete thread");
+      setIsDeleting(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  return (
+    <div className="group relative flex w-full max-w-[280px] items-center justify-between gap-1 rounded-md px-1">
+      <Button
+        variant="ghost"
+        className={cn(
+          "w-full items-start justify-start pr-8 text-left font-normal",
+          isActive && "bg-accent text-accent-foreground",
+        )}
+        onClick={(e) => {
+          e.preventDefault();
+          onThreadClick?.(thread.thread_id);
+        }}
+      >
+        <p className="truncate text-ellipsis">{itemText}</p>
+      </Button>
+
+      {confirmDelete ? (
+        <div className="bg-background/95 border-border absolute right-2 z-10 flex items-center gap-1 rounded-md border p-1 shadow-sm">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-destructive hover:bg-destructive/10 size-6 p-0.5"
+            disabled={isDeleting}
+            onClick={handleDelete}
+            title="Confirm deletion"
+          >
+            {isDeleting ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Check className="size-3.5" />
+            )}
+            <span className="sr-only">Confirm delete</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:bg-accent size-6 p-0.5"
+            disabled={isDeleting}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              setConfirmDelete(false);
+            }}
+            title="Cancel"
+          >
+            <X className="size-3.5" />
+            <span className="sr-only">Cancel</span>
+          </Button>
+        </div>
+      ) : (
+        <div className="absolute right-2 opacity-0 transition-opacity group-hover:opacity-100">
+          <TooltipIconButton
+            tooltip="Delete thread"
+            side="right"
+            className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 size-6 p-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              setConfirmDelete(true);
+            }}
+          >
+            <Trash2 className="size-3.5" />
+          </TooltipIconButton>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function ThreadList({
   threads,
@@ -23,41 +142,55 @@ function ThreadList({
   onThreadClick?: (threadId: string) => void;
 }) {
   const [threadId, setThreadId] = useQueryState("threadId");
+  const { deleteThread, hasMore, loadMoreThreads } = useThreads();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const handleDelete = async (targetThread: Thread) => {
+    await deleteThread(targetThread);
+    if (threadId === targetThread.thread_id) {
+      setThreadId(null);
+    }
+    toast.success("Thread deleted");
+  };
 
   return (
     <div className="flex h-full w-full flex-col items-start justify-start gap-2 overflow-y-scroll [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-track]:bg-transparent">
-      {threads.map((t) => {
-        let itemText = t.thread_id;
-        if (
-          typeof t.values === "object" &&
-          t.values &&
-          "messages" in t.values &&
-          Array.isArray(t.values.messages) &&
-          t.values.messages?.length > 0
-        ) {
-          const firstMessage = t.values.messages[0];
-          itemText = getContentString(firstMessage.content);
-        }
-        return (
-          <div
-            key={t.thread_id}
-            className="w-full px-1"
+      {threads.map((t) => (
+        <ThreadItem
+          key={t.thread_id}
+          thread={t}
+          isActive={t.thread_id === threadId}
+          onThreadClick={(id) => {
+            onThreadClick?.(id);
+            if (id === threadId) return;
+            setThreadId(id);
+          }}
+          onDelete={handleDelete}
+        />
+      ))}
+      {hasMore && (
+        <div className="flex w-full justify-center px-1 py-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground w-[280px] text-xs"
+            disabled={isLoadingMore}
+            onClick={() => {
+              setIsLoadingMore(true);
+              loadMoreThreads().finally(() => setIsLoadingMore(false));
+            }}
           >
-            <Button
-              variant="ghost"
-              className="w-[280px] items-start justify-start text-left font-normal"
-              onClick={(e) => {
-                e.preventDefault();
-                onThreadClick?.(t.thread_id);
-                if (t.thread_id === threadId) return;
-                setThreadId(t.thread_id);
-              }}
-            >
-              <p className="truncate text-ellipsis">{itemText}</p>
-            </Button>
-          </div>
-        );
-      })}
+            {isLoadingMore ? (
+              <>
+                <Loader2 className="mr-2 size-3.5 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              "Load more conversations"
+            )}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -82,17 +215,26 @@ export default function ThreadHistory() {
     parseAsBoolean.withDefault(false),
   );
 
-  const { getThreads, threads, setThreads, threadsLoading, setThreadsLoading } =
-    useThreads();
+  const {
+    getThreads,
+    threads,
+    setThreads,
+    threadsLoading,
+    setThreadsLoading,
+    setHasMore,
+  } = useThreads();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     setThreadsLoading(true);
     getThreads()
-      .then(setThreads)
+      .then((fetched) => {
+        setThreads(fetched);
+        setHasMore(fetched.length >= 100);
+      })
       .catch(console.error)
       .finally(() => setThreadsLoading(false));
-  }, []);
+  }, [getThreads, setHasMore, setThreads, setThreadsLoading]);
 
   return (
     <>

--- a/src/providers/Thread.tsx
+++ b/src/providers/Thread.tsx
@@ -14,11 +14,15 @@ import {
 import { createClient } from "./client";
 
 interface ThreadContextType {
-  getThreads: () => Promise<Thread[]>;
+  getThreads: (limit?: number, offset?: number) => Promise<Thread[]>;
   threads: Thread[];
   setThreads: Dispatch<SetStateAction<Thread[]>>;
   threadsLoading: boolean;
   setThreadsLoading: Dispatch<SetStateAction<boolean>>;
+  hasMore: boolean;
+  setHasMore: Dispatch<SetStateAction<boolean>>;
+  loadMoreThreads: () => Promise<void>;
+  deleteThread: (thread: Thread) => Promise<void>;
 }
 
 const ThreadContext = createContext<ThreadContextType | undefined>(undefined);
@@ -48,25 +52,86 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
   });
   const [threads, setThreads] = useState<Thread[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
-  const getThreads = useCallback(async (): Promise<Thread[]> => {
-    const resolvedAssistantId = assistantId || envAssistantId;
-    if (!apiUrl || !resolvedAssistantId) return [];
-    const client = createClient(
-      apiUrl,
-      getApiKey() ?? undefined,
-      authScheme || undefined,
-    );
+  const getThreads = useCallback(
+    async (limit: number = 100, offset: number = 0): Promise<Thread[]> => {
+      const resolvedAssistantId = assistantId || envAssistantId;
+      if (!apiUrl || !resolvedAssistantId) return [];
+      const client = createClient(
+        apiUrl,
+        getApiKey() ?? undefined,
+        authScheme || undefined,
+      );
 
-    const threads = await client.threads.search({
-      metadata: {
-        ...getThreadSearchMetadata(resolvedAssistantId),
-      },
-      limit: 100,
-    });
+      const threads = await client.threads.search({
+        metadata: {
+          ...getThreadSearchMetadata(resolvedAssistantId),
+        },
+        limit,
+        offset,
+      });
 
-    return threads;
-  }, [apiUrl, assistantId, authScheme, envAssistantId]);
+      return threads;
+    },
+    [apiUrl, assistantId, authScheme, envAssistantId],
+  );
+
+  const loadMoreThreads = useCallback(async (): Promise<void> => {
+    if (isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    try {
+      const newThreads = await getThreads(100, threads.length);
+      if (newThreads.length < 100) {
+        setHasMore(false);
+      } else {
+        setHasMore(true);
+      }
+      setThreads((prev) => {
+        const existingIds = new Set(prev.map((t) => t.thread_id));
+        const filteredNew = newThreads.filter(
+          (t) => !existingIds.has(t.thread_id),
+        );
+        return [...prev, ...filteredNew];
+      });
+    } catch (error) {
+      console.error("Failed to load more threads:", error);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [getThreads, hasMore, isLoadingMore, threads.length]);
+
+  const deleteThread = useCallback(
+    async (thread: Thread): Promise<void> => {
+      const resolvedAssistantId = assistantId || envAssistantId;
+      if (!apiUrl || !resolvedAssistantId) return;
+      const client = createClient(
+        apiUrl,
+        getApiKey() ?? undefined,
+        authScheme || undefined,
+      );
+
+      // Optimistic state update: remove thread immediately for 0ms latency
+      setThreads((prev) =>
+        prev.filter((t) => t.thread_id !== thread.thread_id),
+      );
+
+      try {
+        await client.threads.delete(thread.thread_id);
+      } catch (err) {
+        // Roll back the optimistic removal so the UI stays in sync with the backend.
+        console.error("Failed to delete thread:", err);
+        setThreads((prev) =>
+          prev.some((t) => t.thread_id === thread.thread_id)
+            ? prev
+            : [...prev, thread],
+        );
+        throw err;
+      }
+    },
+    [apiUrl, assistantId, authScheme, envAssistantId],
+  );
 
   const value = {
     getThreads,
@@ -74,6 +139,10 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
     setThreads,
     threadsLoading,
     setThreadsLoading,
+    hasMore,
+    setHasMore,
+    loadMoreThreads,
+    deleteThread,
   };
 
   return (


### PR DESCRIPTION
### Summary
Adds thread deletion capabilities with inline confirmation, optimistic UI state updates with rollback, and paginated conversation loading to the thread history drawer.

### Motivation
In long-running agent deployments, users frequently generate test sessions and accumulated conversation history. Previously:
1. There was no way to delete past threads directly from the history drawer, leaving obsolete threads permanently in the UI.
2. Thread fetching was capped at a hardcoded limit of 100 without pagination support for power users.

### Changes
- **Thread Context (`src/providers/Thread.tsx`)**:
  - Added `deleteThread(thread)` helper utilizing `client.threads.delete()` with optimistic local state removal for instant 0ms UI latency, and graceful rollback (state restore + error surface) if the backend call fails.
  - Added `hasMore`, `setHasMore`, and `loadMoreThreads()` with offset-based pagination and dedup.
  - Parameterized `getThreads(limit?: number, offset?: number)`.
- **History Drawer UI (`src/components/thread/history/index.tsx`)**:
  - Added `ThreadItem` component with hover trash icon, inline confirm/cancel controls, and deletion spinner state. All sub-element click handlers call `e.stopPropagation()` so delete/confirm controls never trigger parent row selection.
  - Added instant toast notifications (`toast.success` / `toast.error`) via `sonner` on both success and failure.
  - Added "Load more conversations" button at drawer footer when `hasMore` is true.
  - Resets active `threadId` query parameter if the currently active conversation is deleted.

### Verification
- `pnpm format:check`: Passed (all files formatted).
- `pnpm lint`: Passed (0 errors).
- `pnpm build`: Next.js production build compiled successfully.